### PR TITLE
[deployer/scripts] Calculate fee with both coins (`uluna` and `uusd`)

### DIFF
--- a/typescript/deployer/cosmos/tx.ts
+++ b/typescript/deployer/cosmos/tx.ts
@@ -1,0 +1,123 @@
+import { encodeSecp256k1Pubkey } from '@cosmjs/amino';
+import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { toUtf8 } from '@cosmjs/encoding';
+import { Uint53 } from '@cosmjs/math';
+import { EncodeObject, type AccountData } from '@cosmjs/proto-signing';
+import { GasPrice, coin } from '@cosmjs/stargate';
+import {
+  ExecuteMsg,
+  InstantiateMsg,
+} from '@mint-cash/burndrop-sdk/types/Burndrop.types';
+import {
+  MsgExecuteContract,
+  MsgInstantiateContract,
+} from 'cosmjs-types/cosmwasm/wasm/v1/tx';
+
+import { config } from '../utils/config';
+
+type EncodeInstantiateMsgProps = {
+  sender: string;
+  msg: InstantiateMsg;
+  label: string;
+  codeId: number;
+};
+export const encodeInstantiateMsg = ({
+  sender,
+  msg,
+  label,
+  codeId,
+}: EncodeInstantiateMsgProps) => ({
+  typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+  value: MsgInstantiateContract.fromPartial({
+    sender,
+    codeId: BigInt(new Uint53(codeId).toString()),
+    label,
+    msg: toUtf8(JSON.stringify(msg)),
+    funds: [],
+    admin: sender,
+  }),
+});
+
+type EncodeExecuteMsgProps = {
+  sender: string;
+  msg: ExecuteMsg;
+  funds: { denom: string; amount: string }[];
+};
+export const encodeExecuteMsg = ({
+  sender,
+  msg,
+  funds,
+}: EncodeExecuteMsgProps) => ({
+  typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+  value: MsgExecuteContract.fromPartial({
+    sender,
+    contract: config.contractAddress,
+    msg: toUtf8(JSON.stringify(msg)),
+    funds,
+  }),
+});
+
+type TrySimulateExecuteMsgProps = {
+  sender: string;
+  encodedMsg: EncodeObject;
+  signingCosmwasmClient: SigningCosmWasmClient;
+};
+export const trySimulateExecuteMsg = async ({
+  sender,
+  encodedMsg,
+  signingCosmwasmClient,
+}: TrySimulateExecuteMsgProps) => {
+  try {
+    const anyMsgs = [encodedMsg].map((m) =>
+      signingCosmwasmClient.registry.encodeAsAny(m),
+    );
+
+    const accountFromSigner = // @ts-ignore
+      (await signingCosmwasmClient.signer.getAccounts()).find(
+        (account: AccountData) => account.address === sender,
+      )!;
+    const pubkey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
+    const { sequence } = await signingCosmwasmClient.getSequence(sender);
+
+    // @ts-ignore
+    const queryClient = signingCosmwasmClient.forceGetQueryClient();
+    const { gasInfo } = await queryClient.tx.simulate(
+      anyMsgs,
+      '',
+      pubkey,
+      sequence,
+    );
+    return gasInfo || null;
+  } catch (err) {
+    console.error('[!] Simulation Error', err);
+    return null;
+  }
+};
+
+export const DEFAULT_GAS = '300000'; // 300K
+export const DEFAULT_GAS_ADJUSTMENT = 1.4;
+
+// 0.01133uluna,0.15uusd
+export const DEFAULT_GAS_PRICES = [
+  GasPrice.fromString('0.01133uluna'),
+  GasPrice.fromString('0.15uusd'),
+];
+
+export const calculateFee = (
+  estimatedGasUsed: bigint | undefined,
+  gasAdjustment: number = DEFAULT_GAS_ADJUSTMENT,
+  gasPrices: GasPrice[] = DEFAULT_GAS_PRICES,
+) => {
+  const gasUsed = Uint53.fromString(
+    estimatedGasUsed?.toString() || DEFAULT_GAS,
+  ).toNumber();
+  const gasLimit = Math.round(gasUsed * gasAdjustment);
+
+  return {
+    amount: gasPrices.map(({ amount, denom }) => {
+      const fee = amount.multiply(new Uint53(gasLimit)).ceil().toString();
+      return coin(fee, denom);
+    }),
+    gas: gasLimit.toString(),
+  };
+};

--- a/typescript/deployer/localterra/2-register_starting_user.ts
+++ b/typescript/deployer/localterra/2-register_starting_user.ts
@@ -1,15 +1,13 @@
 import { ExecuteMsg } from '@mint-cash/burndrop-sdk/types/Burndrop.types';
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
-import { GasPrice, calculateFee } from '@cosmjs/stargate';
-import math from '@cosmjs/math';
-import amino from '@cosmjs/amino';
-import encoding from '@cosmjs/encoding';
-import tx_4 from 'cosmjs-types/cosmwasm/wasm/v1/tx';
-import { config } from '../utils/config';
+import { GasPrice } from '@cosmjs/stargate';
 
-const BURNDROP_CONTRACT_ADDRESS =
-  process.env.BURNDROP_CONTRACT_ADDRESS ||
-  'terra1657pee2jhf4jk8pq6yq64e758ngvum45gl866knmjkd83w6jgn3syqe77g';
+import { config } from '../utils/config';
+import {
+  calculateFee,
+  encodeExecuteMsg,
+  trySimulateExecuteMsg,
+} from '../cosmos/tx';
 
 async function main() {
   const signer = await config.getSigner();
@@ -31,47 +29,23 @@ async function main() {
       user: sender, // self
     },
   };
-  const executeMsg = {
-    typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
-    value: tx_4.MsgExecuteContract.fromPartial({
-      sender,
-      contract: BURNDROP_CONTRACT_ADDRESS,
-      msg: encoding.toUtf8(JSON.stringify(msg)),
-      funds: [],
-    }),
-  };
-
-  const accountFromSigner = (await signer.getAccounts()).find(
-    (account) => account.address === sender,
-  )!;
-  console.log({ accountFromSigner });
-  const pubkey = amino.encodeSecp256k1Pubkey(accountFromSigner.pubkey);
-  console.log(msg, executeMsg);
-  const anyMsgs = [executeMsg].map((m) => client.registry.encodeAsAny(m));
-  const { sequence } = await client.getSequence(sender);
-  // @ts-ignore
-  const queryClient = client.forceGetQueryClient();
-  const { gasInfo } = await queryClient.tx.simulate(
-    anyMsgs,
-    '',
-    pubkey,
-    sequence,
-  );
+  const executeMsg = encodeExecuteMsg({
+    sender,
+    msg,
+    funds: [],
+  });
+  const gasInfo = await trySimulateExecuteMsg({
+    sender,
+    encodedMsg: executeMsg,
+    signingCosmwasmClient: client,
+  });
   console.log(gasInfo);
 
-  const gasEstimation = math.Uint53.fromString(
-    gasInfo?.gasUsed.toString() || '0',
-  ).toNumber();
-  const gasAdjustment = 1.4;
-  const usedFee = calculateFee(
-    Math.round(gasEstimation * gasAdjustment),
-    GasPrice.fromString('0.02uluna'),
-  );
-
+  const calculatedFee = calculateFee(gasInfo?.gasUsed);
   const executeResult = await client.signAndBroadcast(
     sender,
     [executeMsg],
-    usedFee,
+    calculatedFee,
   );
   console.log(executeResult);
   console.log(executeResult.gasUsed, executeResult.gasWanted);

--- a/typescript/deployer/utils/config.ts
+++ b/typescript/deployer/utils/config.ts
@@ -8,10 +8,12 @@ type ConfigArgs = {
   mnemonic?: string;
   privateKey?: string;
   endpoint: string;
+  contractAddress: string;
 };
 
 class Config {
   prefix = 'terra';
+  contractAddress: string = '';
 
   constructor(public args: ConfigArgs) {
     if (!args.mnemonic && !args.privateKey) {
@@ -20,6 +22,7 @@ class Config {
       );
       return;
     }
+    this.contractAddress = args.contractAddress;
   }
 
   async getSigner(): Promise<OfflineSigner> {
@@ -53,4 +56,7 @@ export const config = new Config({
   endpoint: process.env.ENDPOINT || 'http://localhost:26657',
   mnemonic: process.env.MNEMONIC,
   privateKey: process.env.PRIVATE_KEY,
+  contractAddress:
+    process.env.BURNDROP_CONTRACT_ADDRESS ||
+    'terra1657pee2jhf4jk8pq6yq64e758ngvum45gl866knmjkd83w6jgn3syqe77g',
 });


### PR DESCRIPTION
This fixes the contract error `(...) is smaller than (...): insufficient funds: insufficient funds` when broadcasting tx with simulated `gasUsed` — we provide both `coins` in `fee.amount`.